### PR TITLE
bugfix: made sure that only `.gamename` and `.initial_state` are retr…

### DIFF
--- a/retrowrapper.py
+++ b/retrowrapper.py
@@ -81,12 +81,12 @@ class RetroWrapper():
 
         tempenv.reset()
 
-        if hasattr( tempenv, 'unwrapped' ): # Wrappers don't have gamename
-            tempenv = tempenv.unwrapped
+        if hasattr( tempenv, 'unwrapped' ): # Wrappers don't have gamename or initial_state
+            tempenv_unwrapped = tempenv.unwrapped
+            self.gamename = tempenv_unwrapped.gamename
+            self.initial_state = tempenv_unwrapped.initial_state
 
         self.action_space = tempenv.action_space
-        self.gamename = tempenv.gamename
-        self.initial_state = tempenv.initial_state
         self.metadata = tempenv.metadata
         self.observation_space = tempenv.observation_space
         self.reward_range = tempenv.reward_range


### PR DESCRIPTION
…ieved from the unwrapped temporary environment object; other attributes, such as `action_space` should be returned via any applied wrappers

(see Issue https://github.com/MaxStrange/retrowrapper/issues/3)